### PR TITLE
Fix iSH dependencies alpine packages names

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,8 +39,8 @@ else
 	else
 		if [ $numb = "3" ] 
 		then
-			apk add python
 			apk add python3
+			apk add py3-pip
 			apk add dos2unix
 			pip3 install requests
 			pip3 install colorama


### PR DESCRIPTION
Пакета python нет в репозитории alpine linux, соответственно в iSH его не получится поставить. А вместе с пакетом python3 не устанавливается pip