### PR TITLE
Update readme and fix iSH dependencies alpine packages names

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ SMS-спамер<br>
 • <code>sh ~/spymer/install.sh</code><br>
 • <code>spymer</code><br>
 
-<b>Если у вас iOS</a> - скачать <a href="https://apps.apple.com/ru/app/testflight/id899247664">Testflight из App Store</a>, после чего присоедениться к тестированию <a href="https://testflight.apple.com/join/97i7KM8O">iSH в Testflight</a> и прописать команды ниже:<br>
+<b>Если у вас iOS</a> - скачать <a href="https://apps.apple.com/us/app/ish-shell/id1436902243">iSH из App Store</a> и прописать команды ниже:<br>
 • <code>apk update</code><br>
 • <code>apk upgrade</code><br>
 • <code>apk add git</code><br>

--- a/install.sh
+++ b/install.sh
@@ -39,8 +39,8 @@ else
 	else
 		if [ $numb = "3" ] 
 		then
-			apk add python
 			apk add python3
+			apk add py3-pip
 			apk add dos2unix
 			pip3 install requests
 			pip3 install colorama


### PR DESCRIPTION
iSH вышел в релиз в App Store, по этому для того чтобы его скачать больше не нужно присоединяться к его бета тесту в TestFlight, названия пакетов alpine в installl.sh для iSH необходимо исправить так как там нет установки pip, из-за этого не получится установить pip зависимости, для этого нужна установка "py3-pip" (https://pkgs.alpinelinux.org/package/edge/community/x86/py3-pip), пакета "python" в репозитории alpine вообще нет. А скачивание iSH из App Store напрмую позволит не зависить от наличия мест для бета теста, в test flight их может быть не более 10 тысяч, а также обезопасит от исключения из тестирования. 